### PR TITLE
Fix translation

### DIFF
--- a/CRM/PaypalImporter/Transformer.php
+++ b/CRM/PaypalImporter/Transformer.php
@@ -65,7 +65,7 @@ class CRM_PaypalImporter_Transformer
             'contribution_status_id' => self::paypalTransactionStatusToCivicrmContributionStatus($transaction['transaction_info']['transaction_status']),
         ];
         // setup contribution_cancel_date to transaction_updated_date if the contribution status is Refunded
-        if ($contributionData['contribution_status_id'] === self::mapCivicrmContributionLabelToStatus('Refunded')) {
+        if ($contributionData['contribution_status_id'] === self::mapCivicrmContributionLabelToStatus(ts('Refunded'))) {
             $contributionData['contribution_cancel_date'] = $transaction['transaction_info']['transaction_updated_date'];
         }
 
@@ -89,7 +89,7 @@ class CRM_PaypalImporter_Transformer
             'V' => 'Refunded',
         ];
         if (array_key_exists($status, $statusMapping)) {
-            return self::mapCivicrmContributionLabelToStatus($statusMapping[$status]);
+            return self::mapCivicrmContributionLabelToStatus(ts($statusMapping[$status]));
         }
         return 0;
     }
@@ -97,7 +97,7 @@ class CRM_PaypalImporter_Transformer
     /**
      * Map civicrm contribution label to contribution status id.
      *
-     * @param string $label contribution label
+     * @param string $label contribution label. It has to be the localized label.
      *
      * @return int civicrm contribution status id
     */

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/paypal-importer/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-05-20</releaseDate>
-    <version>1.1.1</version>
+    <releaseDate>2021-07-07</releaseDate>
+    <version>1.1.2</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
As it turned out the localization could break the import process. The CRM_Contribute_BAO_Contribution::buildOptions function returns the options with localized labels (for search). Due to this, the contribution_status_id is mapped to the default invalid value, that blocked the contribution creation. To handle this issue, the localized version of the label has to be used for mapping.