### PR TITLE
Status id hardcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # paypal-importer
 
-This module provides paypal data import functionality. This extension contains an API endpoint for starting the transaction process, a cron job for triggering the endpoint every hour, and an admin form to be able to setup the necessary parameters for the Paypal API and for the import process.
+This module provides paypal data import functionality. This extension contains an API endpoint for starting the transaction process, a cron job for triggering the endpoint every hour, and an admin form to be able to setup the necessary parameters for the Paypal API and for the import process. Currently the contribution status id mapping is based on hardcoded ids.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/paypal-importer/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-07-07</releaseDate>
-    <version>1.1.2</version>
+    <releaseDate>2021-07-10</releaseDate>
+    <version>1.2.0</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
As the labels of the contribution status ids could be on fully custom value, the prediction logic could return the fallback 0 values, so that the contribution will be cancelled. To prevent this issue, the ids now wired to the function. The ids were used from a fresh install of the CRM.