### PR TITLE
Format code

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 tabWidth: 4
-printWidth: 100
+printWidth: 120
 trailingComma: 'all'
 singleQuote: true
 bracketSpacing: false

--- a/CRM/PaypalImporter/Config.php
+++ b/CRM/PaypalImporter/Config.php
@@ -37,7 +37,6 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
      * @param array $settings the data to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateSettings(array $settings): bool
@@ -46,6 +45,7 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration['settings'] = $settings;
+
         return parent::update($configuration);
     }
 
@@ -55,7 +55,6 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
      * @param string $state the state name to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateState(string $state): bool
@@ -64,6 +63,7 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration['state'] = $state;
+
         return parent::update($configuration);
     }
 
@@ -73,7 +73,6 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
      * @param array $params the data to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateImportParams(array $params): bool
@@ -82,6 +81,7 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration['import-params'] = $params;
+
         return parent::update($configuration);
     }
 
@@ -91,7 +91,6 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
      * @param array $stats the data to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateImportStats(array $stats): bool
@@ -100,6 +99,7 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration['import-stats'] = $stats;
+
         return parent::update($configuration);
     }
 
@@ -109,7 +109,6 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
      * @param string $error the data to save
      *
      * @return bool the status of the update process.
-     *
      * @throws CRM_Core_Exception.
      */
     public function updateImportError(string $error): bool
@@ -118,6 +117,7 @@ class CRM_PaypalImporter_Config extends CRM_RcBase_Config
         parent::load();
         $configuration = parent::get();
         $configuration['import-error'] = $error;
+
         return parent::update($configuration);
     }
 }

--- a/CRM/PaypalImporter/Form/Settings.php
+++ b/CRM/PaypalImporter/Form/Settings.php
@@ -143,7 +143,7 @@ class CRM_PaypalImporter_Form_Settings extends CRM_Core_Form
             if (!$this->config->updateSettings($submitData)) {
                 CRM_Core_Session::setStatus(ts('Error during save process'), 'Paypal Importer', 'error');
             } else {
-                CRM_Core_Session::setStatus(ts('Data has been updated.'), 'Paypal Importer', 'success', ['expires' => 5000,]);
+                CRM_Core_Session::setStatus(ts('Data has been updated.'), 'Paypal Importer', 'success', ['expires' => 5000]);
                 // on case of the action is selected, handle it. if the current state is do-nothing, push it to import-init
                 // else setup the do-nothing state.
                 if ($this->_submitValues['action']) {

--- a/CRM/PaypalImporter/Form/Settings.php
+++ b/CRM/PaypalImporter/Form/Settings.php
@@ -78,10 +78,10 @@ class CRM_PaypalImporter_Form_Settings extends CRM_Core_Form
         $this->add('datepicker', 'startDate', ts('Transactions later than'), [], true, ['minDate' => date('Y-m-d', strtotime('-3 years', strtotime(date('Y-m-d')))), 'maxDate' => date('Y-m-d')]);
         $this->add('text', 'importLimit', ts('Import limit'), [], true);
         $this->add('text', 'requestLimit', ts('Request limit'), [], true);
-        $this->add('select', 'paymentInstrumentId', ts('Payment method'), [''=>ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'search'), true);
-        $this->add('select', 'financialTypeId', ts('Financial Type'), [''=>ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'), true);
-        $this->add('select', 'tagId', ts('Tag contact'), [0=>ts('- select -')] + CRM_Core_BAO_EntityTag::buildOptions('tag_id', 'search', ['entity_table' => 'civicrm_contact']), false);
-        $this->add('select', 'groupId', ts('Group contact'), [0=>ts('- select -')] +  CRM_Contact_BAO_GroupContact::buildOptions('group_id', 'search', []), false);
+        $this->add('select', 'paymentInstrumentId', ts('Payment method'), ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('payment_instrument_id', 'search'), true);
+        $this->add('select', 'financialTypeId', ts('Financial Type'), ['' => ts('- select -')] + CRM_Contribute_BAO_Contribution::buildOptions('financial_type_id', 'search'), true);
+        $this->add('select', 'tagId', ts('Tag contact'), [0 => ts('- select -')] + CRM_Core_BAO_EntityTag::buildOptions('tag_id', 'search', ['entity_table' => 'civicrm_contact']), false);
+        $this->add('select', 'groupId', ts('Group contact'), [0 => ts('- select -')] + CRM_Contact_BAO_GroupContact::buildOptions('group_id', 'search', []), false);
         // checkbox for triggering the state change of the application.
         // - if current state is do-nothing, start action, if set bumps the state to import-init
         if ($config['state'] == 'do-nothing') {

--- a/CRM/PaypalImporter/ImportProcess.php
+++ b/CRM/PaypalImporter/ImportProcess.php
@@ -131,7 +131,6 @@ class CRM_PaypalImporter_ImportProcess
      * It returns the resultset of the transaction search.
      *
      * @return array API result
-     *
      * @throws API_Exception
      */
     private function getTransactionData(): array
@@ -147,6 +146,7 @@ class CRM_PaypalImporter_ImportProcess
             CRM_PaypalImporter_Upgrader::logError('Paypal transaction search failure');
             throw new API_Exception('Paypal transaction search failure', 'paypal_transaction_search_failure');
         }
+
         return json_decode($transactionResponse['data'], true);
     }
 
@@ -200,6 +200,7 @@ class CRM_PaypalImporter_ImportProcess
         $emailData = CRM_PaypalImporter_Transformer::paypalTransactionToEmail($transaction);
         if (empty($emailData['email'])) {
             $this->addInfo($transaction['transaction_info']['transaction_id'].' | Skipping transaction due to missing email address.');
+
             return;
         }
         // Try to find a contact to the email. If not found, we have to insert a contact and also the email.
@@ -211,6 +212,7 @@ class CRM_PaypalImporter_ImportProcess
                 $this->stats['new-user'] += 1;
             } catch (Exception $e) {
                 $this->addError(sprintf('%s (transaction_id: %s)', $e->getMessage(), $transaction['transaction_info']['transaction_id']));
+
                 return;
             }
             try {
@@ -275,6 +277,7 @@ class CRM_PaypalImporter_ImportProcess
         ];
         $this->config->updateImportParams($importParams);
         $cfg = $this->config->get();
+
         return $cfg['import-params']['page'];
     }
 
@@ -316,10 +319,8 @@ class CRM_PaypalImporter_ImportProcess
      *
      * @return array
      *   API result descriptor
-     *
      * @throws API_Exception
      * @see civicrm_api3_create_success
-     *
      */
     public function run($params)
     {
@@ -367,6 +368,7 @@ class CRM_PaypalImporter_ImportProcess
         $this->stats['execution-time'] = $this->getExecutionTime();
         $this->stats['number-of-requests'] = $this->numberOfRequests;
         $this->config->updateImportStats($this->stats);
+
         return civicrm_api3_create_success(['stats' => $this->stats], $params, 'PaypalDataImport', 'Process');
     }
 }

--- a/CRM/PaypalImporter/Loader.php
+++ b/CRM/PaypalImporter/Loader.php
@@ -10,7 +10,6 @@ class CRM_PaypalImporter_Loader
      * @param array $contactData Contact data
      *
      * @return int Contact ID
-     *
      * @throws CRM_Core_Exception
      */
     public static function contact(array $contactData): int
@@ -25,7 +24,6 @@ class CRM_PaypalImporter_Loader
      * @param array $emailData email data
      *
      * @return int Email ID
-     *
      * @throws CRM_Core_Exception
      */
     public static function email(int $contactId, array $emailData): int
@@ -40,7 +38,6 @@ class CRM_PaypalImporter_Loader
      * @param array $contributionData contribution data
      *
      * @return int Contribution ID
-     *
      * @throws CRM_Core_Exception
      */
     public static function contribution(int $contactId, array $contributionData): int
@@ -57,6 +54,7 @@ class CRM_PaypalImporter_Loader
             return CRM_RcBase_Api_Create::contribution($contactId, $contributionData, false);
         } else {
             CRM_RcBase_Api_Update::entity('Contribution', $contribution['id'], $contributionData, false);
+
             return $contribution['id'];
         }
     }

--- a/CRM/PaypalImporter/Request/Auth.php
+++ b/CRM/PaypalImporter/Request/Auth.php
@@ -3,6 +3,7 @@
 class CRM_PaypalImporter_Request_Auth extends CRM_PaypalImporter_Request_Base
 {
     public const ENDPOINT = '/v1/oauth2/token';
+
     public const CONTENT_TYPE_HEADER = 'multipart/form-data';
 
     /**
@@ -30,9 +31,9 @@ class CRM_PaypalImporter_Request_Auth extends CRM_PaypalImporter_Request_Base
     private static function curlHeaders(string $clientId, string $clientSecret): array
     {
         return [
-            'Accept: '. parent::ACCEPT_HEADER,
-            'Accept-Language: '. parent::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '. self::CONTENT_TYPE_HEADER,
+            'Accept: '.parent::ACCEPT_HEADER,
+            'Accept-Language: '.parent::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.self::CONTENT_TYPE_HEADER,
             'Authorization: Basic '.base64_encode($clientId.':'.$clientSecret),
         ];
     }

--- a/CRM/PaypalImporter/Request/Base.php
+++ b/CRM/PaypalImporter/Request/Base.php
@@ -7,6 +7,7 @@
 class CRM_PaypalImporter_Request_Base
 {
     public const ACCEPT_HEADER = 'application/json';
+
     public const ACCEPT_LANGUAGE_HEADER = 'en_US';
 
     /**
@@ -93,7 +94,7 @@ class CRM_PaypalImporter_Request_Base
             return strlen($data);
         }
 
-        list($key, $value) = explode(":", $trimmedData, 2);
+        [$key, $value] = explode(":", $trimmedData, 2);
 
         $key = trim($key);
         $value = trim($value);
@@ -145,7 +146,7 @@ class CRM_PaypalImporter_Request_Base
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($this->requestData));
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-        curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, 'parseResponseHeaders'));
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, [$this, 'parseResponseHeaders']);
         //Execute Curl Request
         $this->responseData = curl_exec($ch);
         //Retrieve Response Status
@@ -170,7 +171,7 @@ class CRM_PaypalImporter_Request_Base
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->requestHeaders);
-        curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, 'parseResponseHeaders'));
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, [$this, 'parseResponseHeaders']);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
         //Execute Curl Request
         $this->responseData = curl_exec($ch);

--- a/CRM/PaypalImporter/Request/Transactions.php
+++ b/CRM/PaypalImporter/Request/Transactions.php
@@ -3,6 +3,7 @@
 class CRM_PaypalImporter_Request_Transactions extends CRM_PaypalImporter_Request_Base
 {
     public const ENDPOINT = '/v1/reporting/transactions';
+
     public const CONTENT_TYPE_HEADER = 'application/json';
 
     /**
@@ -29,9 +30,9 @@ class CRM_PaypalImporter_Request_Transactions extends CRM_PaypalImporter_Request
     private static function curlHeaders(string $accessToken): array
     {
         return [
-            'Accept: '. parent::ACCEPT_HEADER,
-            'Accept-Language: '. parent::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '. self::CONTENT_TYPE_HEADER,
+            'Accept: '.parent::ACCEPT_HEADER,
+            'Accept-Language: '.parent::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.self::CONTENT_TYPE_HEADER,
             'Authorization: Bearer '.$accessToken,
         ];
     }

--- a/CRM/PaypalImporter/Request/TransactionsCodeMock.php
+++ b/CRM/PaypalImporter/Request/TransactionsCodeMock.php
@@ -14,7 +14,6 @@ class CRM_PaypalImporter_Request_TransactionsCodeMock
     {
     }
 
-
     /**
      * Performs a post request.
      */

--- a/CRM/PaypalImporter/Request/TransactionsMissingEmailMock.php
+++ b/CRM/PaypalImporter/Request/TransactionsMissingEmailMock.php
@@ -3,6 +3,7 @@
 class CRM_PaypalImporter_Request_TransactionsMissingEmailMock
 {
     public const TRANSACTION_ID = '5TY05013RG002845M';
+
     /**
      * Default Constructor
      *
@@ -14,7 +15,6 @@ class CRM_PaypalImporter_Request_TransactionsMissingEmailMock
     public function __construct(string $host, string $accessToken, array $searchParams = [])
     {
     }
-
 
     /**
      * Performs a post request.
@@ -40,7 +40,9 @@ class CRM_PaypalImporter_Request_TransactionsMissingEmailMock
         return [
             'code' => 200,
             'headers' => [],
-            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_ID.'","transaction_initiation_date":"2014-07-11T04:03:52+0000","transaction_amount":{"value":"1000","currency_code":"USD"}},"payer_info":{}}], "total_pages":1, "last_refreshed_datetime": "'.date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
+            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_ID
+                .'","transaction_initiation_date":"2014-07-11T04:03:52+0000","transaction_amount":{"value":"1000","currency_code":"USD"}},"payer_info":{}}], "total_pages":1, "last_refreshed_datetime": "'
+                .date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
         ];
     }
 }

--- a/CRM/PaypalImporter/Request/TransactionsMock.php
+++ b/CRM/PaypalImporter/Request/TransactionsMock.php
@@ -2,7 +2,8 @@
 
 class CRM_PaypalImporter_Request_TransactionsMock
 {
-    public const TRANSACTION_IDS = ['5TY05013RG002845M','5TY05013RG002846M'];
+    public const TRANSACTION_IDS = ['5TY05013RG002845M', '5TY05013RG002846M'];
+
     /**
      * Default Constructor
      *
@@ -14,7 +15,6 @@ class CRM_PaypalImporter_Request_TransactionsMock
     public function __construct(string $host, string $accessToken, array $searchParams = [])
     {
     }
-
 
     /**
      * Performs a post request.
@@ -40,7 +40,11 @@ class CRM_PaypalImporter_Request_TransactionsMock
         return [
             'code' => 200,
             'headers' => [],
-            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[0].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -55 days")).'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer1@example.com", "payer_name": {"given_name": "test","surname": "consumer1"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}},{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[1].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -50 days")).'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer2@example.com", "payer_name": {"given_name": "test","surname": "consumer2"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}}], "total_pages":1, "last_refreshed_datetime": "'.date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
+            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[0].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -55 days"))
+                .'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer1@example.com", "payer_name": {"given_name": "test","surname": "consumer1"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}},{"transaction_info":{"transaction_id":"'
+                .self::TRANSACTION_IDS[1].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -50 days"))
+                .'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer2@example.com", "payer_name": {"given_name": "test","surname": "consumer2"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}}], "total_pages":1, "last_refreshed_datetime": "'
+                .date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
         ];
     }
 }

--- a/CRM/PaypalImporter/Request/TransactionsPagingMock.php
+++ b/CRM/PaypalImporter/Request/TransactionsPagingMock.php
@@ -2,7 +2,8 @@
 
 class CRM_PaypalImporter_Request_TransactionsPagingMock
 {
-    public const TRANSACTION_IDS = ['5TY05013RG002848M','5TY05013RG002849M'];
+    public const TRANSACTION_IDS = ['5TY05013RG002848M', '5TY05013RG002849M'];
+
     /**
      * Default Constructor
      *
@@ -14,7 +15,6 @@ class CRM_PaypalImporter_Request_TransactionsPagingMock
     public function __construct(string $host, string $accessToken, array $searchParams = [])
     {
     }
-
 
     /**
      * Performs a post request.
@@ -40,7 +40,11 @@ class CRM_PaypalImporter_Request_TransactionsPagingMock
         return [
             'code' => 200,
             'headers' => [],
-            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[0].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -55 days")).'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer1@example.com", "payer_name": {"given_name": "test","surname": "consumer1"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}},{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[1].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -50 days")).'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer2@example.com", "payer_name": {"given_name": "test","surname": "consumer2"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}}], "total_pages":3, "last_refreshed_datetime": "'.date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
+            'data' => '{"transaction_details":[{"transaction_info":{"transaction_id":"'.self::TRANSACTION_IDS[0].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -55 days"))
+                .'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer1@example.com", "payer_name": {"given_name": "test","surname": "consumer1"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}},{"transaction_info":{"transaction_id":"'
+                .self::TRANSACTION_IDS[1].'","transaction_initiation_date":"'.date(DATE_ISO8601, strtotime("now -50 days"))
+                .'","transaction_amount":{"value":"1000.00","currency_code":"HUF"},"fee_amount":{"value":"-100.00","currency_code":"HUF"}, "transaction_status":"S"},"payer_info":{"email_address": "consumer2@example.com", "payer_name": {"given_name": "test","surname": "consumer2"}},"cart_info": {"item_details": [{"item_name": "Item1 - radio"}]}}], "total_pages":3, "last_refreshed_datetime": "'
+                .date(DATE_ISO8601, strtotime("now -12 hours")).'"}',
         ];
     }
 }

--- a/CRM/PaypalImporter/Transformer.php
+++ b/CRM/PaypalImporter/Transformer.php
@@ -3,8 +3,11 @@
 class CRM_PaypalImporter_Transformer
 {
     const CRM_FAILED_STATUS_ID = 4;
+
     const CRM_REFUNDED_STATUS_ID = 7;
+
     const CRM_PENDING_STATUS_ID = 2;
+
     const CRM_COMPLETED_STATUS_ID = 1;
 
     /**
@@ -101,6 +104,7 @@ class CRM_PaypalImporter_Transformer
         if (array_key_exists($status, $statusMapping)) {
             return $statusMapping[$status];
         }
+
         return 0;
     }
 }

--- a/CRM/PaypalImporter/Upgrader/Base.php
+++ b/CRM/PaypalImporter/Upgrader/Base.php
@@ -53,15 +53,14 @@ class CRM_PaypalImporter_Upgrader_Base
                 E::path()
             );
         }
+
         return self::$instance;
     }
 
     /**
      * Adapter that lets you add normal (non-static) member functions to the queue.
-     *
      * Note: Each upgrader instance should only be associated with one
      * task-context; otherwise, this will be non-reentrant.
-     *
      * ```
      * CRM_PaypalImporter_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
      * ```
@@ -73,6 +72,7 @@ class CRM_PaypalImporter_Upgrader_Base
         $instance->ctx = array_shift($args);
         $instance->queue = $instance->ctx->queue;
         $method = array_shift($args);
+
         return call_user_func_array([$instance, $method], $args);
     }
 
@@ -95,11 +95,13 @@ class CRM_PaypalImporter_Upgrader_Base
      *
      * @param string $relativePath
      *   the CustomData XML file path (relative to this extension's dir)
+     *
      * @return bool
      */
     public function executeCustomDataFile($relativePath)
     {
-        $xml_file = $this->extensionDir . '/' . $relativePath;
+        $xml_file = $this->extensionDir.'/'.$relativePath;
+
         return $this->executeCustomDataFileByAbsPath($xml_file);
     }
 
@@ -115,6 +117,7 @@ class CRM_PaypalImporter_Upgrader_Base
     {
         $import = new CRM_Utils_Migrate_Import();
         $import->run($xml_file);
+
         return true;
     }
 
@@ -130,8 +133,9 @@ class CRM_PaypalImporter_Upgrader_Base
     {
         CRM_Utils_File::sourceSQLFile(
             CIVICRM_DSN,
-            $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
+            $this->extensionDir.DIRECTORY_SEPARATOR.$relativePath
         );
+
         return true;
     }
 
@@ -150,7 +154,7 @@ class CRM_PaypalImporter_Upgrader_Base
         // Assign multilingual variable to Smarty.
         $upgrade = new CRM_Upgrade_Form();
 
-        $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
+        $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir.DIRECTORY_SEPARATOR.$tplFile;
         $smarty = CRM_Core_Smarty::singleton();
         $smarty->assign('domainID', CRM_Core_Config::domainID());
         CRM_Utils_File::sourceSQLFile(
@@ -159,12 +163,12 @@ class CRM_PaypalImporter_Upgrader_Base
             null,
             true
         );
+
         return true;
     }
 
     /**
      * Run one SQL query.
-     *
      * This is just a wrapper for CRM_Core_DAO::executeSql, but it
      * provides syntactic sugar for queueing several tasks that
      * run different queries
@@ -175,15 +179,14 @@ class CRM_PaypalImporter_Upgrader_Base
     {
         // FIXME verify that we raise an exception on error
         CRM_Core_DAO::executeQuery($query, $params);
+
         return true;
     }
 
     /**
      * Syntactic sugar for enqueuing a task which calls a function in this class.
-     *
      * The task is weighted so that it is processed
      * as part of the currently-pending revision.
-     *
      * After passing the $funcName, you can also pass parameters that will go to
      * the function. Note that all params must be serializable.
      */
@@ -196,6 +199,7 @@ class CRM_PaypalImporter_Upgrader_Base
             $args,
             $title
         );
+
         return $this->queue->createItem($task, ['weight' => -1]);
     }
 
@@ -234,15 +238,15 @@ class CRM_PaypalImporter_Upgrader_Base
         foreach ($this->getRevisions() as $revision) {
             if ($revision > $currentRevision) {
                 $title = E::ts('Upgrade %1 to revision %2', [
-          1 => $this->extensionName,
-          2 => $revision,
-        ]);
+                    1 => $this->extensionName,
+                    2 => $revision,
+                ]);
 
                 // note: don't use addTask() because it sets weight=-1
 
                 $task = new CRM_Queue_Task(
                     [get_class($this), '_queueAdapter'],
-                    ['upgrade_' . $revision],
+                    ['upgrade_'.$revision],
                     $title
                 );
                 $this->queue->createItem($task);
@@ -287,15 +291,17 @@ class CRM_PaypalImporter_Upgrader_Base
         if (!$revision) {
             $revision = $this->getCurrentRevisionDeprecated();
         }
+
         return $revision;
     }
 
     private function getCurrentRevisionDeprecated()
     {
-        $key = $this->extensionName . ':version';
+        $key = $this->extensionName.':version';
         if ($revision = \Civi::settings()->get($key)) {
             $this->revisionStorageIsDeprecated = true;
         }
+
         return $revision;
     }
 
@@ -304,6 +310,7 @@ class CRM_PaypalImporter_Upgrader_Base
         CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
         // clean up legacy schema version store (CRM-19252)
         $this->deleteDeprecatedRevision();
+
         return true;
     }
 
@@ -311,7 +318,7 @@ class CRM_PaypalImporter_Upgrader_Base
     {
         if ($this->revisionStorageIsDeprecated) {
             $setting = new CRM_Core_BAO_Setting();
-            $setting->name = $this->extensionName . ':version';
+            $setting->name = $this->extensionName.':version';
             $setting->delete();
             CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
         }
@@ -324,19 +331,19 @@ class CRM_PaypalImporter_Upgrader_Base
      */
     public function onInstall()
     {
-        $files = glob($this->extensionDir . '/sql/*_install.sql');
+        $files = glob($this->extensionDir.'/sql/*_install.sql');
         if (is_array($files)) {
             foreach ($files as $file) {
                 CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
             }
         }
-        $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
+        $files = glob($this->extensionDir.'/sql/*_install.mysql.tpl');
         if (is_array($files)) {
             foreach ($files as $file) {
                 $this->executeSqlTemplate($file);
             }
         }
-        $files = glob($this->extensionDir . '/xml/*_install.xml');
+        $files = glob($this->extensionDir.'/xml/*_install.xml');
         if (is_array($files)) {
             foreach ($files as $file) {
                 $this->executeCustomDataFileByAbsPath($file);
@@ -366,7 +373,7 @@ class CRM_PaypalImporter_Upgrader_Base
      */
     public function onUninstall()
     {
-        $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
+        $files = glob($this->extensionDir.'/sql/*_uninstall.mysql.tpl');
         if (is_array($files)) {
             foreach ($files as $file) {
                 $this->executeSqlTemplate($file);
@@ -375,7 +382,7 @@ class CRM_PaypalImporter_Upgrader_Base
         if (is_callable([$this, 'uninstall'])) {
             $this->uninstall();
         }
-        $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
+        $files = glob($this->extensionDir.'/sql/*_uninstall.sql');
         if (is_array($files)) {
             foreach ($files as $file) {
                 CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);

--- a/api/v3/PaypalDataImport/Process.mgd.php
+++ b/api/v3/PaypalDataImport/Process.mgd.php
@@ -4,17 +4,17 @@
 // database as appropriate. For more details, see "hook_civicrm_managed" at:
 // https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
 return [
-  [
-    'name' => 'Cron:PaypalDataImport.Process',
-    'entity' => 'Job',
-    'params' => [
-      'version' => 3,
-      'name' => 'Call PaypalDataImport.Process API',
-      'description' => 'Call PaypalDataImport.Process API',
-      'run_frequency' => 'Hourly',
-      'api_entity' => 'PaypalDataImport',
-      'api_action' => 'Process',
-      'parameters' => '',
+    [
+        'name' => 'Cron:PaypalDataImport.Process',
+        'entity' => 'Job',
+        'params' => [
+            'version' => 3,
+            'name' => 'Call PaypalDataImport.Process API',
+            'description' => 'Call PaypalDataImport.Process API',
+            'run_frequency' => 'Hourly',
+            'api_entity' => 'PaypalDataImport',
+            'api_action' => 'Process',
+            'parameters' => '',
+        ],
     ],
-  ],
 ];

--- a/api/v3/PaypalDataImport/Process.php
+++ b/api/v3/PaypalDataImport/Process.php
@@ -1,4 +1,5 @@
 <?php
+
 use CRM_PaypalImporter_ExtensionUtil as E;
 
 /**
@@ -20,13 +21,12 @@ function _civicrm_api3_paypal_data_import_Process_spec(&$spec)
  *
  * @return array
  *   API result descriptor
- *
- * @see civicrm_api3_create_success
- *
  * @throws API_Exception
+ * @see civicrm_api3_create_success
  */
 function civicrm_api3_paypal_data_import_Process($params)
 {
     $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, CRM_PaypalImporter_Request_Auth::class, CRM_PaypalImporter_Request_Transactions::class);
+
     return $p->run($params);
 }

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/paypal-importer/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-11-08</releaseDate>
-    <version>1.3.0</version>
+    <releaseDate>2023-03-08</releaseDate>
+    <version>1.3.1</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/paypal_importer.civix.php
+++ b/paypal_importer.civix.php
@@ -9,18 +9,20 @@
 class CRM_PaypalImporter_ExtensionUtil
 {
     const SHORT_NAME = 'paypal_importer';
+
     const LONG_NAME = 'paypal-importer';
+
     const CLASS_PREFIX = 'CRM_PaypalImporter';
 
     /**
      * Translate a string using the extension's domain.
-     *
      * If the extension doesn't have a specific translation
      * for the string, fallback to the default translations.
      *
      * @param string $text
      *   Canonical message text (generally en_US).
      * @param array $params
+     *
      * @return string
      *   Translated text.
      * @see ts
@@ -30,6 +32,7 @@ class CRM_PaypalImporter_ExtensionUtil
         if (!array_key_exists('domain', $params)) {
             $params['domain'] = [self::LONG_NAME, null];
         }
+
         return ts($text, $params);
     }
 
@@ -39,6 +42,7 @@ class CRM_PaypalImporter_ExtensionUtil
      * @param string|NULL $file
      *   Ex: NULL.
      *   Ex: 'css/foo.css'.
+     *
      * @return string
      *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
      *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -48,6 +52,7 @@ class CRM_PaypalImporter_ExtensionUtil
         if ($file === null) {
             return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
         }
+
         return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
 
@@ -57,6 +62,7 @@ class CRM_PaypalImporter_ExtensionUtil
      * @param string|NULL $file
      *   Ex: NULL.
      *   Ex: 'css/foo.css'.
+     *
      * @return string
      *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
      *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -64,7 +70,7 @@ class CRM_PaypalImporter_ExtensionUtil
     public static function path($file = null)
     {
         // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
-        return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
+        return __DIR__.($file === null ? '' : (DIRECTORY_SEPARATOR.$file));
     }
 
     /**
@@ -72,12 +78,13 @@ class CRM_PaypalImporter_ExtensionUtil
      *
      * @param string $suffix
      *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+     *
      * @return string
      *   Ex: 'CRM_Foo_Page_HelloWorld'.
      */
     public static function findClass($suffix)
     {
-        return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+        return self::CLASS_PREFIX.'_'.str_replace('\\', '_', $suffix);
     }
 }
 
@@ -98,8 +105,8 @@ function _paypal_importer_civix_civicrm_config(&$config = null)
 
     $template =& CRM_Core_Smarty::singleton();
 
-    $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-    $extDir = $extRoot . 'templates';
+    $extRoot = dirname(__FILE__).DIRECTORY_SEPARATOR;
+    $extDir = $extRoot.'templates';
 
     if (is_array($template->template_dir)) {
         array_unshift($template->template_dir, $extDir);
@@ -107,7 +114,7 @@ function _paypal_importer_civix_civicrm_config(&$config = null)
         $template->template_dir = [$extDir, $template->template_dir];
     }
 
-    $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+    $include_path = $extRoot.PATH_SEPARATOR.get_include_path();
     set_include_path($include_path);
 }
 
@@ -120,7 +127,7 @@ function _paypal_importer_civix_civicrm_config(&$config = null)
  */
 function _paypal_importer_civix_civicrm_xmlMenu(&$files)
 {
-    foreach (_paypal_importer_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+    foreach (_paypal_importer_civix_glob(__DIR__.'/xml/Menu/*.xml') as $file) {
         $files[] = $file;
     }
 }
@@ -206,7 +213,6 @@ function _paypal_importer_civix_civicrm_disable()
  * @return mixed
  *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *   for 'enqueue', returns void
- *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _paypal_importer_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
@@ -221,7 +227,7 @@ function _paypal_importer_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = nu
  */
 function _paypal_importer_civix_upgrader()
 {
-    if (!file_exists(__DIR__ . '/CRM/PaypalImporter/Upgrader.php')) {
+    if (!file_exists(__DIR__.'/CRM/PaypalImporter/Upgrader.php')) {
         return null;
     } else {
         return CRM_PaypalImporter_Upgrader_Base::instance();
@@ -230,7 +236,6 @@ function _paypal_importer_civix_upgrader()
 
 /**
  * Search directory tree for files which match a glob pattern.
- *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
@@ -256,7 +261,7 @@ function _paypal_importer_civix_find_files($dir, $pattern)
         }
         if ($dh = opendir($subdir)) {
             while (false !== ($entry = readdir($dh))) {
-                $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+                $path = $subdir.DIRECTORY_SEPARATOR.$entry;
                 if ($entry[0] == '.') {
                 } elseif (is_dir($path)) {
                     $todos[] = $path;
@@ -265,12 +270,12 @@ function _paypal_importer_civix_find_files($dir, $pattern)
             closedir($dh);
         }
     }
+
     return $result;
 }
 
 /**
  * (Delegated) Implements hook_civicrm_managed().
- *
  * Find any *.mgd.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
@@ -295,49 +300,45 @@ function _paypal_importer_civix_civicrm_managed(&$entities)
 
 /**
  * (Delegated) Implements hook_civicrm_caseTypes().
- *
  * Find any and return any files matching "xml/case/*.xml"
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _paypal_importer_civix_civicrm_caseTypes(&$caseTypes)
 {
-    if (!is_dir(__DIR__ . '/xml/case')) {
+    if (!is_dir(__DIR__.'/xml/case')) {
         return;
     }
 
-    foreach (_paypal_importer_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    foreach (_paypal_importer_civix_glob(__DIR__.'/xml/case/*.xml') as $file) {
         $name = preg_replace('/\.xml$/', '', basename($file));
         if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
             $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
             throw new CRM_Core_Exception($errorMessage);
         }
         $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
+            'module' => E::LONG_NAME,
+            'name' => $name,
+            'file' => $file,
+        ];
     }
 }
 
 /**
  * (Delegated) Implements hook_civicrm_angularModules().
- *
  * Find any and return any files matching "ang/*.ang.php"
- *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _paypal_importer_civix_civicrm_angularModules(&$angularModules)
 {
-    if (!is_dir(__DIR__ . '/ang')) {
+    if (!is_dir(__DIR__.'/ang')) {
         return;
     }
 
-    $files = _paypal_importer_civix_glob(__DIR__ . '/ang/*.ang.php');
+    $files = _paypal_importer_civix_glob(__DIR__.'/ang/*.ang.php');
     foreach ($files as $file) {
         $name = preg_replace(':\.ang\.php$:', '', basename($file));
         $module = include $file;
@@ -350,12 +351,11 @@ function _paypal_importer_civix_civicrm_angularModules(&$angularModules)
 
 /**
  * (Delegated) Implements hook_civicrm_themes().
- *
  * Find any and return any files matching "*.theme.php"
  */
 function _paypal_importer_civix_civicrm_themes(&$themes)
 {
-    $files = _paypal_importer_civix_glob(__DIR__ . '/*.theme.php');
+    $files = _paypal_importer_civix_glob(__DIR__.'/*.theme.php');
     foreach ($files as $file) {
         $themeMeta = include $file;
         if (empty($themeMeta['name'])) {
@@ -370,13 +370,13 @@ function _paypal_importer_civix_civicrm_themes(&$themes)
 
 /**
  * Glob wrapper which is guaranteed to return an array.
- *
  * The documentation for glob() says, "On some systems it is impossible to
  * distinguish between empty match and an error." Anecdotally, the return
  * result for an empty match is sometimes array() and sometimes FALSE.
  * This wrapper provides consistency.
  *
  * @link http://php.net/glob
+ *
  * @param string $pattern
  *
  * @return array
@@ -384,6 +384,7 @@ function _paypal_importer_civix_civicrm_themes(&$themes)
 function _paypal_importer_civix_glob($pattern)
 {
     $result = glob($pattern);
+
     return is_array($result) ? $result : [];
 }
 
@@ -403,11 +404,12 @@ function _paypal_importer_civix_insert_navigation_menu(&$menu, $path, $item)
     // If we are done going down the path, insert menu
     if (empty($path)) {
         $menu[] = [
-      'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
-      ], $item),
-    ];
+            'attributes' => array_merge([
+                'label' => CRM_Utils_Array::value('name', $item),
+                'active' => 1,
+            ], $item),
+        ];
+
         return true;
     } else {
         // Find an recurse into the next level down
@@ -422,6 +424,7 @@ function _paypal_importer_civix_insert_navigation_menu(&$menu, $path, $item)
                 $found = _paypal_importer_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
             }
         }
+
         return $found;
     }
 }
@@ -479,7 +482,7 @@ function _paypal_importer_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $par
  */
 function _paypal_importer_civix_civicrm_alterSettingsFolders(&$metaDataFolders = null)
 {
-    $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+    $settingsDir = __DIR__.DIRECTORY_SEPARATOR.'settings';
     if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
         $metaDataFolders[] = $settingsDir;
     }
@@ -487,7 +490,6 @@ function _paypal_importer_civix_civicrm_alterSettingsFolders(&$metaDataFolders =
 
 /**
  * (Delegated) Implements hook_civicrm_entityTypes().
- *
  * Find any *.entityType.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/paypal_importer.php
+++ b/paypal_importer.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'paypal_importer.civix.php';
+
 // phpcs:disable
 use CRM_PaypalImporter_ExtensionUtil as E;
 
@@ -88,7 +89,6 @@ function paypal_importer_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
 
 /**
  * Implements hook_civicrm_managed().
- *
  * Generate a list of entities to create/deactivate/delete when this module
  * is installed, disabled, uninstalled.
  *
@@ -101,9 +101,7 @@ function paypal_importer_civicrm_managed(&$entities)
 
 /**
  * Implements hook_civicrm_caseTypes().
- *
  * Generate a list of case-types.
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -115,9 +113,7 @@ function paypal_importer_civicrm_caseTypes(&$caseTypes)
 
 /**
  * Implements hook_civicrm_angularModules().
- *
  * Generate a list of Angular modules.
- *
  * Note: This hook only runs in CiviCRM 4.5+. It may
  * use features only available in v4.6+.
  *
@@ -140,7 +136,6 @@ function paypal_importer_civicrm_alterSettingsFolders(&$metaDataFolders = null)
 
 /**
  * Implements hook_civicrm_entityTypes().
- *
  * Declare entity types provided by this module.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/tests/phpunit/CRM/PaypalImporter/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/ConfigHeadlessTest.php
@@ -196,7 +196,7 @@ class CRM_PaypalImporter_ConfigHeadlessTest extends CRM_PaypalImporter_HeadlessB
         $cfg['import-stats'] = [
             'new-user' => 1,
             'transaction' => 2,
-            'errors' => []
+            'errors' => [],
         ];
         self::assertTrue($config->updateImportStats($cfg['import-stats']), 'Update config has to be successful.');
         $cfgUpdated = $config->get();

--- a/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
@@ -29,6 +29,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
         ],
         'import-error' => '',
     ];
+
     private function setupTestConfig()
     {
         $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
@@ -84,6 +85,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
         }
         self::assertSame('Paypal data importer', $form->getTitle(), 'Invalid form title.');
     }
+
     public function testBuildQuickFormImportInitState()
     {
         $this->setupTestConfig();
@@ -98,6 +100,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
         }
         self::assertSame('Paypal data importer', $form->getTitle(), 'Invalid form title.');
     }
+
     public function testBuildQuickFormImportError()
     {
         $this->setupTestConfig();
@@ -112,6 +115,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
         }
         self::assertSame('Paypal data importer', $form->getTitle(), 'Invalid form title.');
     }
+
     public function testBuildQuickFormImportStats()
     {
         $this->setupTestConfig();
@@ -198,6 +202,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
             self::fail('It shouldn\'t throw exception. '.$e->getMessage());
         }
     }
+
     public function testPostProcessWithActionDefaultState()
     {
         $_POST['clientId'] = 'client-id';
@@ -224,6 +229,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends CRM_PaypalImporter_HeadlessBa
         $cfg = $config->get();
         self::assertSame('import-init', $cfg['state'], 'Invalid state after start the action.');
     }
+
     public function testPostProcessWithActionImportState()
     {
         $_POST['clientId'] = 'client-id';

--- a/tests/phpunit/CRM/PaypalImporter/ImportProcessTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/ImportProcessTest.php
@@ -14,6 +14,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
 {
     // We don't use the params in the process script.
     const PARAMS = [];
+
     const TEST_SETTINGS = [
         'settings' => [
             'client-id' => '',
@@ -34,6 +35,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         ],
         'import-error' => '',
     ];
+
     private function setupTestConfig()
     {
         $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
@@ -67,6 +69,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
             self::assertIsFloat($result['values']['stats']['execution-time']);
         }
     }
+
     public function testRunFailedAuthWrongCode()
     {
         $this->setupTestConfig();
@@ -76,6 +79,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
+
     public function testRunFailedAuthMissingToken()
     {
         $this->setupTestConfig();
@@ -85,6 +89,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
+
     public function testRunSuccessfulAuth()
     {
         $this->setupTestConfig();
@@ -109,6 +114,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::assertTrue(array_key_exists('errors', $result['values']['stats']));
         self::assertSame([], $result['values']['stats']['errors']);
     }
+
     public function testRunTransactionSearchFail()
     {
         $this->setupTestConfig();
@@ -118,6 +124,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
+
     public function testRunTransactionSearchNoTransactionsAfterInit()
     {
         $this->setupTestConfig();
@@ -154,7 +161,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         $cfg = $config->get();
         // the page has to be 1 again, and the start date has to be increased with 30 days.
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the first iteration');
-        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'] .' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
+        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
         // next iteration, page 1, date increased with 30 days again.
         $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsNoTransactionMock');
@@ -162,7 +169,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         $config->load();
         $cfg = $config->get();
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the second iteration');
-        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'] .' + 60 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the second iteration');
+        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 60 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the second iteration');
         self::assertSame('import', $cfg['state']);
         // last iteration, sync state.
         $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsNoTransactionMock');
@@ -172,6 +179,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the last iteration');
         self::assertSame('sync', $cfg['state'], 'Invalid final state.');
     }
+
     public function testRunTransactionWithoutEmailData()
     {
         $this->setupTestConfig();
@@ -208,9 +216,10 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         $cfg = $config->get();
         // the page has to be 1 again, and the start date has to be increased with 30 days.
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the first iteration');
-        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'] .' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
+        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
     }
+
     public function testRunTransactionWithTransactions()
     {
         $this->setupTestConfig();
@@ -247,9 +256,10 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         $cfg = $config->get();
         // the page has to be 1 again, and the start date has to be increased with 30 days.
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the first iteration');
-        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'] .' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
+        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
     }
+
     public function testRunTransactionWithTransactionsSetupTagAndGroup()
     {
         $this->setupTestConfig();
@@ -296,7 +306,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         $cfg = $config->get();
         // the page has to be 1 again, and the start date has to be increased with 30 days.
         self::assertSame(1, $cfg['import-params']['page'], 'Invalid page after the first iteration');
-        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'] .' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
+        self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
         // Run the same import again, to check the tag, group logic is not failing.
         $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsMock');
@@ -315,6 +325,7 @@ class CRM_PaypalImporter_ImportProcessTest extends CRM_PaypalImporter_Request_Te
         self::assertTrue(array_key_exists('errors', $result['values']['stats']));
         self::assertSame([], $result['values']['stats']['errors']);
     }
+
     public function testRunTransactionWithTransactionsPaging()
     {
         $this->setupTestConfig();

--- a/tests/phpunit/CRM/PaypalImporter/LoaderHeadlessTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/LoaderHeadlessTest.php
@@ -20,6 +20,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         $contactId = CRM_PaypalImporter_Loader::contact($contactData);
         self::assertIsInt($contactId);
     }
+
     public function testContactValidData()
     {
         $contactData = [
@@ -49,6 +50,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         self::expectExceptionMessage('Argument 1 passed to CRM_PaypalImporter_Loader::email() must be of the type int, null given');
         $emailId = CRM_PaypalImporter_Loader::email(null, $emailData);
     }
+
     public function testEmailInvalidContactId()
     {
         $emailData = ['email' => 'testlooser@email.com'];
@@ -56,6 +58,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         self::expectExceptionMessage('Invalid ID');
         $emailId = CRM_PaypalImporter_Loader::email(-1, $emailData);
     }
+
     public function testEmailMissingEmailData()
     {
         // create contact with the loader
@@ -70,6 +73,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         self::expectExceptionMessage('Failed to create Email, reason: Mandatory values missing from Api4 Email::create: email');
         $emailId = CRM_PaypalImporter_Loader::email($contactId, $emailData);
     }
+
     public function testEmailValidData()
     {
         // create contact with the loader
@@ -101,6 +105,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         self::expectExceptionMessage('Argument 1 passed to CRM_PaypalImporter_Loader::contribution() must be of the type int, null given');
         $contributionId = CRM_PaypalImporter_Loader::contribution(null, $contribData);
     }
+
     public function testContributionInvalidContactId()
     {
         $contribData = ['trxn_id' => 'a-1', 'total_amount' => 10];
@@ -108,6 +113,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         self::expectExceptionMessage('Invalid ID');
         $emailId = CRM_PaypalImporter_Loader::contribution(-1, $contribData);
     }
+
     public function testContributionValidDataInsert()
     {
         // create contact with the loader
@@ -138,6 +144,7 @@ class CRM_PaypalImporter_LoaderHeadlessTest extends CRM_PaypalImporter_HeadlessB
         $contribution = $contributions->first();
         self::assertSame($contribData['trxn_id'], $contribution['trxn_id'], 'Invalid transaction has been returned');
     }
+
     public function testContributionValidDataUpdate()
     {
         // create contact with the loader

--- a/tests/phpunit/CRM/PaypalImporter/Request/AuthTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Request/AuthTest.php
@@ -27,6 +27,7 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
             'clientSecret' => '',
         ],
     ];
+
     const EXPECTED_OPTIONS = [
         CURLOPT_SSLVERSION => 6,
         CURLOPT_CONNECTTIMEOUT => 10,
@@ -38,6 +39,7 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
         CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2,
         CURLOPT_FOLLOWLOCATION => true,
     ];
+
     const EXPECTED_DATA = [
         'grant_type' => 'client_credentials',
     ];
@@ -53,6 +55,7 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
+
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -60,6 +63,7 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame(CRM_PaypalImporter_Request_Auth::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
+
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -67,12 +71,13 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame(self::EXPECTED_OPTIONS, $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
+
     public function testGetRequestHeaders()
     {
         $expectedHeaderBase = [
-            'Accept: '. CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
-            'Accept-Language: '. CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '. CRM_PaypalImporter_Request_Auth::CONTENT_TYPE_HEADER,
+            'Accept: '.CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
+            'Accept-Language: '.CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.CRM_PaypalImporter_Request_Auth::CONTENT_TYPE_HEADER,
             'Authorization: Basic ',
         ];
         foreach (self::TEST_DATA as $settings) {
@@ -81,6 +86,7 @@ class CRM_PaypalImporter_Request_AuthTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($expectedHeaderBase, $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
+
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {

--- a/tests/phpunit/CRM/PaypalImporter/Request/BaseTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Request/BaseTest.php
@@ -67,6 +67,7 @@ class CRM_PaypalImporter_Request_BaseTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
+
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -74,6 +75,7 @@ class CRM_PaypalImporter_Request_BaseTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($settings['endpoint'], $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
+
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -81,6 +83,7 @@ class CRM_PaypalImporter_Request_BaseTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($settings['options'], $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
+
     public function testGetRequestHeaders()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -88,6 +91,7 @@ class CRM_PaypalImporter_Request_BaseTest extends CRM_PaypalImporter_Request_Tes
             self::assertSame($settings['headers'], $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
+
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -106,6 +110,7 @@ class CRM_PaypalImporter_Request_BaseTest extends CRM_PaypalImporter_Request_Tes
             self::assertEmpty($req->get());
         }
     }
+
     public function testPost()
     {
         foreach (self::TEST_DATA as $settings) {

--- a/tests/phpunit/CRM/PaypalImporter/Request/TransactionsTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Request/TransactionsTest.php
@@ -33,6 +33,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends CRM_PaypalImporter_Req
             ],
         ],
     ];
+
     const EXPECTED_OPTIONS = [
         CURLOPT_SSLVERSION => 6,
         CURLOPT_CONNECTTIMEOUT => 10,
@@ -56,6 +57,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends CRM_PaypalImporter_Req
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
+
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -63,6 +65,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends CRM_PaypalImporter_Req
             self::assertSame(CRM_PaypalImporter_Request_Transactions::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
+
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
@@ -70,12 +73,13 @@ class CRM_PaypalImporter_Request_TransactionsTest extends CRM_PaypalImporter_Req
             self::assertSame(self::EXPECTED_OPTIONS, $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
+
     public function testGetRequestHeaders()
     {
         $expectedHeaderBase = [
-            'Accept: '. CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
-            'Accept-Language: '. CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '. CRM_PaypalImporter_Request_Transactions::CONTENT_TYPE_HEADER,
+            'Accept: '.CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
+            'Accept-Language: '.CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.CRM_PaypalImporter_Request_Transactions::CONTENT_TYPE_HEADER,
             'Authorization: Basic ',
         ];
         foreach (self::TEST_DATA as $settings) {
@@ -84,6 +88,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends CRM_PaypalImporter_Req
             self::assertSame($expectedHeaderBase, $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
+
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {

--- a/tests/phpunit/CRM/PaypalImporter/TransformerHeadlessTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/TransformerHeadlessTest.php
@@ -8,139 +8,139 @@
 class CRM_PaypalImporter_TransformerHeadlessTest extends CRM_PaypalImporter_HeadlessBase
 {
     const PAYPAL_SAMPLE_DATA = [
-        "transaction_info"=> [
-            "paypal_account_id"=> "6STWC2LSUYYYE",
-            "transaction_id"=> "5TY05013RG002845M",
-            "transaction_event_code"=> "T0006",
-            "transaction_initiation_date"=> "2014-07-11T04:03:52+0000",
-            "transaction_updated_date"=> "2014-07-11T04:03:52+0000",
-            "transaction_amount"=> [
-                "currency_code"=> "USD",
-                "value"=> "465.00"
+        "transaction_info" => [
+            "paypal_account_id" => "6STWC2LSUYYYE",
+            "transaction_id" => "5TY05013RG002845M",
+            "transaction_event_code" => "T0006",
+            "transaction_initiation_date" => "2014-07-11T04:03:52+0000",
+            "transaction_updated_date" => "2014-07-11T04:03:52+0000",
+            "transaction_amount" => [
+                "currency_code" => "USD",
+                "value" => "465.00",
             ],
-            "fee_amount"=> [
-                "currency_code"=> "USD",
-                "value"=> "-13.79"
+            "fee_amount" => [
+                "currency_code" => "USD",
+                "value" => "-13.79",
             ],
-            "insurance_amount"=> [
-                "currency_code"=> "USD",
-                "value"=> "15.00"
+            "insurance_amount" => [
+                "currency_code" => "USD",
+                "value" => "15.00",
             ],
-            "shipping_amount"=> [
-                "currency_code"=> "USD",
-                "value"=> "30.00"
+            "shipping_amount" => [
+                "currency_code" => "USD",
+                "value" => "30.00",
             ],
-            "shipping_discount_amount"=> [
-                "currency_code"=> "USD",
-                "value"=> "10.00"
+            "shipping_discount_amount" => [
+                "currency_code" => "USD",
+                "value" => "10.00",
             ],
-            "transaction_status"=> "S",
-            "transaction_subject"=> "Bill for your purchase",
-            "transaction_note"=> "Check out the latest sales",
-            "invoice_id"=> "Invoice-005",
-            "custom_field"=> "Thank you for your business",
-            "protection_eligibility"=> "01"
+            "transaction_status" => "S",
+            "transaction_subject" => "Bill for your purchase",
+            "transaction_note" => "Check out the latest sales",
+            "invoice_id" => "Invoice-005",
+            "custom_field" => "Thank you for your business",
+            "protection_eligibility" => "01",
         ],
-        "payer_info"=> [
-            "account_id"=> "6STWC2LSUYYYE",
-            "email_address"=> "consumer@example.com",
-            "address_status"=> "Y",
-            "payer_status"=> "Y",
-            "payer_name"=> [
-                "given_name"=> "test",
-                "surname"=> "consumer",
-                "alternate_full_name"=> "test consumer"
+        "payer_info" => [
+            "account_id" => "6STWC2LSUYYYE",
+            "email_address" => "consumer@example.com",
+            "address_status" => "Y",
+            "payer_status" => "Y",
+            "payer_name" => [
+                "given_name" => "test",
+                "surname" => "consumer",
+                "alternate_full_name" => "test consumer",
             ],
-            "country_code"=> "US"
+            "country_code" => "US",
         ],
-        "shipping_info"=> [
-            "name"=> "Sowmith",
-            "address"=> [
-                "line1"=> "Eco Space, bellandur",
-                "line2"=> "OuterRingRoad",
-                "city"=> "Bangalore",
-                "country_code"=> "IN",
-                "postal_code"=> "560103"
-            ]
+        "shipping_info" => [
+            "name" => "Sowmith",
+            "address" => [
+                "line1" => "Eco Space, bellandur",
+                "line2" => "OuterRingRoad",
+                "city" => "Bangalore",
+                "country_code" => "IN",
+                "postal_code" => "560103",
+            ],
         ],
-        "cart_info"=> [
-            "item_details"=> [
+        "cart_info" => [
+            "item_details" => [
                 [
-                    "item_code"=> "ItemCode-1",
-                    "item_name"=> "Item1 - radio",
-                    "item_description"=> "Radio",
-                    "item_quantity"=> "2",
-                    "item_unit_price"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "50.00"
+                    "item_code" => "ItemCode-1",
+                    "item_name" => "Item1 - radio",
+                    "item_description" => "Radio",
+                    "item_quantity" => "2",
+                    "item_unit_price" => [
+                        "currency_code" => "USD",
+                        "value" => "50.00",
                     ],
-                    "item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "100.00"
+                    "item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "100.00",
                     ],
-                    "tax_amounts"=> [
+                    "tax_amounts" => [
                         [
-                            "tax_amount"=> [
-                                "currency_code"=> "USD",
-                                "value"=> "20.00"
-                            ]
-                        ]
+                            "tax_amount" => [
+                                "currency_code" => "USD",
+                                "value" => "20.00",
+                            ],
+                        ],
                     ],
-                    "total_item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "120.00"
+                    "total_item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "120.00",
                     ],
-                    "invoice_number"=> "Invoice-005"
+                    "invoice_number" => "Invoice-005",
                 ],
                 [
-                    "item_code"=> "ItemCode-2",
-                    "item_name"=> "Item2 - Headset",
-                    "item_description"=> "Headset",
-                    "item_quantity"=> "3",
-                    "item_unit_price"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "100.00"
+                    "item_code" => "ItemCode-2",
+                    "item_name" => "Item2 - Headset",
+                    "item_description" => "Headset",
+                    "item_quantity" => "3",
+                    "item_unit_price" => [
+                        "currency_code" => "USD",
+                        "value" => "100.00",
                     ],
-                    "item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "300.00"
+                    "item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "300.00",
                     ],
-                    "tax_amounts"=> [
+                    "tax_amounts" => [
                         [
-                            "tax_amount"=> [
-                                "currency_code"=> "USD",
-                                "value"=> "60.00"
-                            ]
-                        ]
+                            "tax_amount" => [
+                                "currency_code" => "USD",
+                                "value" => "60.00",
+                            ],
+                        ],
                     ],
-                    "total_item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "360.00"
+                    "total_item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "360.00",
                     ],
-                    "invoice_number"=> "Invoice-005"
+                    "invoice_number" => "Invoice-005",
                 ],
                 [
-                    "item_name"=> "3",
-                    "item_quantity"=> "1",
-                    "item_unit_price"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "-50.00"
+                    "item_name" => "3",
+                    "item_quantity" => "1",
+                    "item_unit_price" => [
+                        "currency_code" => "USD",
+                        "value" => "-50.00",
                     ],
-                    "item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "-50.00"
+                    "item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "-50.00",
                     ],
-                    "total_item_amount"=> [
-                        "currency_code"=> "USD",
-                        "value"=> "-50.00"
+                    "total_item_amount" => [
+                        "currency_code" => "USD",
+                        "value" => "-50.00",
                     ],
-                    "invoice_number"=> "Invoice-005"
-                ]
-            ]
+                    "invoice_number" => "Invoice-005",
+                ],
+            ],
         ],
-        "store_info"=> [],
-        "auction_info"=> [],
-        "incentive_info"=> []
+        "store_info" => [],
+        "auction_info" => [],
+        "incentive_info" => [],
     ];
 
     /**
@@ -177,27 +177,28 @@ class CRM_PaypalImporter_TransformerHeadlessTest extends CRM_PaypalImporter_Head
     {
         $expectedContributionData = [
             'total_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
-            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10)*-1,
+            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10) * -1,
             'non_deductible_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
             'trxn_id' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_id'],
             'receive_date' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_initiation_date'],
             'invoice_number' => self::PAYPAL_SAMPLE_DATA['transaction_info']['invoice_id'],
-            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '' ,
+            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '',
             'contribution_status_id' => 1,
         ];
         $transformedContribution = CRM_PaypalImporter_Transformer::paypalTransactionToContribution(self::PAYPAL_SAMPLE_DATA);
         self::assertSame($expectedContributionData, $transformedContribution, 'Invalid transformed data.');
     }
+
     public function testPaypalTransactionToCivicrmContributionRefund()
     {
         $expectedContributionData = [
             'total_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
-            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10)*-1,
+            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10) * -1,
             'non_deductible_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
             'trxn_id' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_id'],
             'receive_date' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_initiation_date'],
             'invoice_number' => self::PAYPAL_SAMPLE_DATA['transaction_info']['invoice_id'],
-            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '' ,
+            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '',
             'contribution_status_id' => 7,
             'contribution_cancel_date' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_updated_date'],
         ];
@@ -206,16 +207,17 @@ class CRM_PaypalImporter_TransformerHeadlessTest extends CRM_PaypalImporter_Head
         $transformedContribution = CRM_PaypalImporter_Transformer::paypalTransactionToContribution($refundTransaction);
         self::assertSame($expectedContributionData, $transformedContribution, 'Invalid transformed data.');
     }
+
     public function testPaypalTransactionToCivicrmContributionNotMappedStatus()
     {
         $expectedContributionData = [
             'total_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
-            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10)*-1,
+            'fee_amount' => intval(self::PAYPAL_SAMPLE_DATA['transaction_info']['fee_amount']['value'], 10) * -1,
             'non_deductible_amount' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_amount']['value'],
             'trxn_id' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_id'],
             'receive_date' => self::PAYPAL_SAMPLE_DATA['transaction_info']['transaction_initiation_date'],
             'invoice_number' => self::PAYPAL_SAMPLE_DATA['transaction_info']['invoice_id'],
-            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '' ,
+            'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '',
             'contribution_status_id' => 0,
         ];
         $refundTransaction = self::PAYPAL_SAMPLE_DATA;

--- a/tests/phpunit/api/v3/PaypalDataImport/ProcessTest.php
+++ b/tests/phpunit/api/v3/PaypalDataImport/ProcessTest.php
@@ -5,6 +5,7 @@ use CRM_PaypalImporter_ExtensionUtil as E;
 /**
  * PaypalDataImport.Process API Test Case
  * This is a generic test class implemented with PHPUnit.
+ *
  * @group headless
  */
 class api_v3_PaypalDataImport_ProcessTest extends CRM_PaypalImporter_HeadlessBase

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -20,6 +20,7 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
  * @throws \RuntimeException
@@ -27,8 +28,8 @@ $loader->register();
  */
 function cv($cmd, $decode = 'json')
 {
-    $cmd = 'cv ' . $cmd;
-    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
     putenv("CV_OUTPUT=json");
 
@@ -53,6 +54,7 @@ function cv($cmd, $decode = 'json')
             if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
                 throw new \RuntimeException("Command failed ($cmd):\n$result");
             }
+
             return $result;
 
         case 'json':


### PR DESCRIPTION
- Reformat PHP to PSR-12
- Reformat JS
- readme: use hyphens for `cv en some-extension`
- remove `,` after last element of inline arrays
