### PR TITLE
Move classes to \Civi namespace

### DIFF
--- a/CRM/PaypalImporter/Form/Settings.php
+++ b/CRM/PaypalImporter/Form/Settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\PaypalImporter\Config;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
 /**
@@ -12,7 +13,7 @@ class CRM_PaypalImporter_Form_Settings extends CRM_Core_Form
     /**
      * Configdb
      *
-     * @var CRM_PaypalImporter_Config
+     * @var Config
      */
     private $config;
 
@@ -23,7 +24,7 @@ class CRM_PaypalImporter_Form_Settings extends CRM_Core_Form
     public function preProcess(): void
     {
         // Get current settings
-        $this->config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $this->config = new Config(E::LONG_NAME);
         $this->config->load();
     }
 

--- a/CRM/PaypalImporter/Upgrader.php
+++ b/CRM/PaypalImporter/Upgrader.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\PaypalImporter\Config;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
 /**
@@ -26,7 +27,7 @@ class CRM_PaypalImporter_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function install(): void
     {
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         // Create default configs
         if (!$config->create()) {
             CRM_PaypalImporter_Upgrader::logError(E::LONG_NAME.ts(' could not create configs in database'));
@@ -41,7 +42,7 @@ class CRM_PaypalImporter_Upgrader extends CRM_Extension_Upgrader_Base
      */
     public function uninstall(): void
     {
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         // delete current configs
         if (!$config->remove()) {
             CRM_PaypalImporter_Upgrader::logError(E::LONG_NAME.ts(' could not remove configs from database'));

--- a/Civi/PaypalImporter/Config.php
+++ b/Civi/PaypalImporter/Config.php
@@ -1,6 +1,11 @@
 <?php
 
-class CRM_PaypalImporter_Config extends CRM_RcBase_Config
+namespace Civi\PaypalImporter;
+
+use CRM_Core_Exception;
+use CRM_RcBase_Config;
+
+class Config extends CRM_RcBase_Config
 {
     /**
      * Provides a default configuration object.

--- a/Civi/PaypalImporter/Loader.php
+++ b/Civi/PaypalImporter/Loader.php
@@ -1,8 +1,13 @@
 <?php
 
-use Civi\Api4\Contribution;
+namespace Civi\PaypalImporter;
 
-class CRM_PaypalImporter_Loader
+use Civi\Api4\Contribution;
+use CRM_Core_Exception;
+use CRM_RcBase_Api_Create;
+use CRM_RcBase_Api_Update;
+
+class Loader
 {
     /**
      * Import new contact

--- a/Civi/PaypalImporter/Request/Auth.php
+++ b/Civi/PaypalImporter/Request/Auth.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_Auth extends CRM_PaypalImporter_Request_Base
+namespace Civi\PaypalImporter\Request;
+
+class Auth extends Base
 {
     public const ENDPOINT = '/v1/oauth2/token';
 

--- a/Civi/PaypalImporter/Request/Base.php
+++ b/Civi/PaypalImporter/Request/Base.php
@@ -3,6 +3,7 @@
 namespace Civi\PaypalImporter\Request;
 
 use CRM_PaypalImporter_Upgrader;
+use Exception;
 
 /**
  * HTTP request class. It is responsible for the curl call. Based on the deprecated sdk.

--- a/Civi/PaypalImporter/Request/Base.php
+++ b/Civi/PaypalImporter/Request/Base.php
@@ -1,10 +1,14 @@
 <?php
 
+namespace Civi\PaypalImporter\Request;
+
+use CRM_PaypalImporter_Upgrader;
+
 /**
  * HTTP request class. It is responsible for the curl call. Based on the deprecated sdk.
  * https://github.com/paypal/PayPal-PHP-SDK/blob/1a2ed767bb09374a8a222069930e94fccf99009e/lib/PayPal/Core/PayPalHttpConnection.php
  */
-class CRM_PaypalImporter_Request_Base
+class Base
 {
     public const ACCEPT_HEADER = 'application/json';
 

--- a/Civi/PaypalImporter/Request/Transactions.php
+++ b/Civi/PaypalImporter/Request/Transactions.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_Transactions extends CRM_PaypalImporter_Request_Base
+namespace Civi\PaypalImporter\Request;
+
+class Transactions extends Base
 {
     public const ENDPOINT = '/v1/reporting/transactions';
 

--- a/Civi/PaypalImporter/Transformer.php
+++ b/Civi/PaypalImporter/Transformer.php
@@ -1,6 +1,10 @@
 <?php
 
-class CRM_PaypalImporter_Transformer
+namespace Civi\PaypalImporter;
+
+use CRM_RcBase_Api_Get;
+
+class Transformer
 {
     const CRM_FAILED_STATUS_ID = 4;
 

--- a/Civi/PaypalImporter/Transformer.php
+++ b/Civi/PaypalImporter/Transformer.php
@@ -6,13 +6,13 @@ use CRM_RcBase_Api_Get;
 
 class Transformer
 {
-    const CRM_FAILED_STATUS_ID = 4;
+    public const CRM_FAILED_STATUS_ID = 4;
 
-    const CRM_REFUNDED_STATUS_ID = 7;
+    public const CRM_REFUNDED_STATUS_ID = 7;
 
-    const CRM_PENDING_STATUS_ID = 2;
+    public const CRM_PENDING_STATUS_ID = 2;
 
-    const CRM_COMPLETED_STATUS_ID = 1;
+    public const CRM_COMPLETED_STATUS_ID = 1;
 
     /**
      * Transform paypal transaction data to civicrm contact data

--- a/api/v3/PaypalImporter/Import.php
+++ b/api/v3/PaypalImporter/Import.php
@@ -1,5 +1,8 @@
 <?php
 
+use Civi\PaypalImporter\ImportProcess;
+use Civi\PaypalImporter\Request\Auth;
+use Civi\PaypalImporter\Request\Transactions;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
 /**
@@ -13,7 +16,7 @@ use CRM_PaypalImporter_ExtensionUtil as E;
  */
 function civicrm_api3_paypal_importer_Import($params): array
 {
-    $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, CRM_PaypalImporter_Request_Auth::class, CRM_PaypalImporter_Request_Transactions::class);
+    $p = new ImportProcess(E::LONG_NAME, Auth::class, Transactions::class);
 
     return $p->run($params);
 }

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/paypal-importer/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-21</releaseDate>
-    <version>1.6.0</version>
+    <releaseDate>2023-04-07</releaseDate>
+    <version>2.0.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.38</ver>

--- a/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
@@ -9,7 +9,7 @@ use CRM_PaypalImporter_ExtensionUtil as E;
  */
 class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
 {
-    const TEST_SETTINGS = [
+    public const TEST_SETTINGS = [
         'settings' => [
             'client-id' => '',
             'client-secret' => '',

--- a/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
+++ b/tests/phpunit/CRM/PaypalImporter/Form/SettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\PaypalImporter\Config;
 use Civi\PaypalImporter\HeadlessTestCase;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
@@ -34,7 +35,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
      */
     private function setupTestConfig()
     {
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         self::assertTrue($config->update(self::TEST_SETTINGS), 'Config update has to be successful.');
     }
 
@@ -59,7 +60,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
     public function testPreProcessMissingConfig()
     {
         $form = new CRM_PaypalImporter_Form_Settings();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->remove();
         self::expectException(CRM_Core_Exception::class);
         self::expectExceptionMessage(E::LONG_NAME.'_config config invalid.');
@@ -90,7 +91,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
     public function testBuildQuickFormImportInitState()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $form = new CRM_PaypalImporter_Form_Settings();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
@@ -109,7 +110,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
     public function testBuildQuickFormImportError()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('error');
         $form = new CRM_PaypalImporter_Form_Settings();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
@@ -128,7 +129,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
     public function testBuildQuickFormImportStats()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $form = new CRM_PaypalImporter_Form_Settings();
         $config->updateImportStats(['new-user' => 2, 'transaction' => 2, 'error' => ['Something went wrong.']]);
@@ -148,7 +149,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
     public function testSetDefaultValues()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('error');
         $form = new CRM_PaypalImporter_Form_Settings();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
@@ -239,7 +240,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
         } catch (Exception $e) {
             self::fail('It shouldn\'t throw exception. '.$e->getMessage());
         }
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->load();
         $cfg = $config->get();
         self::assertSame('import-init', $cfg['state'], 'Invalid state after start the action.');
@@ -263,7 +264,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
         $_POST['tagId'] = 0;
         $_POST['groupId'] = 0;
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import');
         $form = new CRM_PaypalImporter_Form_Settings();
         self::assertEmpty($form->preProcess(), 'PreProcess supposed to be empty.');
@@ -272,7 +273,7 @@ class CRM_PaypalImporter_Form_SettingsTest extends HeadlessTestCase
         } catch (Exception $e) {
             self::fail('It shouldn\'t throw exception. '.$e->getMessage());
         }
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->load();
         $cfg = $config->get();
         self::assertSame('do-nothing', $cfg['state'], 'Invalid state after start the action.');

--- a/tests/phpunit/Civi/PaypalImporter/ConfigTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/ConfigTest.php
@@ -1,11 +1,13 @@
 <?php
 
-use Civi\PaypalImporter\HeadlessTestCase;
+namespace Civi\PaypalImporter;
+
+use CRM_Core_Exception;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
+class ConfigTest extends HeadlessTestCase
 {
     /**
      * @return void
@@ -13,7 +15,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testCreate()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         self::assertTrue(array_key_exists('settings', $cfg), 'settings key is missing from the config.');
@@ -54,7 +56,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testRemove()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         self::assertTrue($config->remove(), 'Remove config has to be successful.');
     }
@@ -65,7 +67,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testGet()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         self::assertTrue(array_key_exists('settings', $cfg), 'settings key is missing from the config.');
@@ -110,7 +112,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdate()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['settings']['client-id'] = 'new-client-id';
@@ -125,20 +127,20 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testLoad()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['settings']['client-id'] = 'new-client-id';
         self::assertTrue($config->update($cfg), 'Update config has to be successful.');
         $cfgUpdated = $config->get();
         self::assertEquals($cfg, $cfgUpdated, 'Invalid updated configuration.');
-        $otherConfig = new CRM_PaypalImporter_Config('paypal_test');
+        $otherConfig = new Config('paypal_test');
         self::assertEmpty($otherConfig->load(), 'Load result supposed to be empty.');
 
         $cfgLoaded = $otherConfig->get();
         self::assertEquals($cfg, $cfgLoaded, 'Invalid loaded configuration.');
 
-        $missingConfig = new CRM_PaypalImporter_Config('paypal_test_missing_config');
+        $missingConfig = new Config('paypal_test_missing_config');
         self::expectException(CRM_Core_Exception::class);
         self::expectExceptionMessage('paypal_test_missing_config_config config invalid.');
         self::assertEmpty($missingConfig->load(), 'Load result supposed to be empty.');
@@ -150,7 +152,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdateSettings()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['settings']['client-id'] = 'new-client-id';
@@ -165,7 +167,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function updateState()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['state'] = 'error';
@@ -180,7 +182,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdateImportParams()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['import-params'] = [
@@ -198,7 +200,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdateImportStats()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['import-stats'] = [
@@ -217,7 +219,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdateImportError()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['import-error'] = 'new-issue something went wrong.';
@@ -232,7 +234,7 @@ class CRM_PaypalImporter_ConfigTest extends HeadlessTestCase
      */
     public function testUpdateState()
     {
-        $config = new CRM_PaypalImporter_Config('paypal_test');
+        $config = new Config('paypal_test');
         self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
         $cfg['state'] = 'import';

--- a/tests/phpunit/Civi/PaypalImporter/ImportProcessTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/ImportProcessTest.php
@@ -1,14 +1,17 @@
 <?php
 
+namespace Civi\PaypalImporter;
+
+use API_Exception;
 use Civi\Api4\Group;
 use Civi\Api4\Tag;
-use Civi\PaypalImporter\HeadlessTestCase;
+use Civi\PaypalImporter\Request\TransactionsMissingEmailMock;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
+class ImportProcessTest extends HeadlessTestCase
 {
     // We don't use the params in the process script.
     const PARAMS = [];
@@ -39,7 +42,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
      */
     private function setupTestConfig()
     {
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         self::assertTrue($config->update(self::TEST_SETTINGS), 'Config update has to be successful.');
     }
 
@@ -52,10 +55,10 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     {
         $this->setupTestConfig();
         $states = ['do-nothing'];
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         foreach ($states as $state) {
             $config->updateState($state);
-            $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'fake_auth_class_name', 'fake_transactions_class_name');
+            $p = new ImportProcess(E::LONG_NAME, 'fake_auth_class_name', 'fake_transactions_class_name');
             $result = $p->run(self::PARAMS);
             $config->load();
             $cfg = $config->get();
@@ -79,9 +82,9 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunFailedAuthWrongCode()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthCodeMock', 'fake_transactions_class_name');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthCodeMock', 'fake_transactions_class_name');
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
@@ -94,9 +97,9 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunFailedAuthMissingToken()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthTokenMock', 'fake_transactions_class_name');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthTokenMock', 'fake_transactions_class_name');
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
@@ -109,13 +112,13 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunSuccessfulAuth()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         // decrease request limit to 0, to prevent the transaction search call.
         $cfg = $config->get();
         $cfg['settings']['request-limit'] = 0;
         $config->updateSettings($cfg['settings']);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'fake_transactions_class_name');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'fake_transactions_class_name');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -139,9 +142,9 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionSearchFail()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsCodeMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsCodeMock');
         self::expectException(API_Exception::class);
         $p->run(self::PARAMS);
     }
@@ -154,7 +157,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionSearchNoTransactionsAfterInit()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $settings = [
             'client-id' => 'clientid',
@@ -169,7 +172,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
             'group-id' => 0,
         ];
         $config->updateSettings($settings);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsNoTransactionMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsNoTransactionMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -190,7 +193,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
         self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
         // next iteration, page 1, date increased with 30 days again.
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsNoTransactionMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsNoTransactionMock');
         $result = $p->run(self::PARAMS);
         $config->load();
         $cfg = $config->get();
@@ -198,7 +201,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
         self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 60 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the second iteration');
         self::assertSame('import', $cfg['state']);
         // last iteration, sync state.
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsNoTransactionMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsNoTransactionMock');
         $result = $p->run(self::PARAMS);
         $config->load();
         $cfg = $config->get();
@@ -214,7 +217,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionWithoutEmailData()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $settings = [
             'client-id' => 'clientid',
@@ -229,7 +232,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
             'group-id' => 0,
         ];
         $config->updateSettings($settings);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsMissingEmailMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsMissingEmailMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -242,7 +245,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
         self::assertTrue(array_key_exists('transaction', $result['values']['stats']));
         self::assertSame(0, $result['values']['stats']['transaction']);
         self::assertTrue(array_key_exists('errors', $result['values']['stats']));
-        self::assertSame([CRM_PaypalImporter_Request_TransactionsMissingEmailMock::TRANSACTION_ID.' | Skipping transaction due to missing email address.'], $result['values']['stats']['errors']);
+        self::assertSame([TransactionsMissingEmailMock::TRANSACTION_ID.' | Skipping transaction due to missing email address.'], $result['values']['stats']['errors']);
         $config->load();
         $cfg = $config->get();
         // the page has to be 1 again, and the start date has to be increased with 30 days.
@@ -259,7 +262,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionWithTransactions()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $settings = [
             'client-id' => 'clientid',
@@ -274,7 +277,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
             'group-id' => 0,
         ];
         $config->updateSettings($settings);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -305,7 +308,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionWithTransactionsSetupTagAndGroup()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $tagId = Tag::create()
             ->addValue('name', 'My Tag')
@@ -329,7 +332,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
             'group-id' => (int)$groupId->first()['id'],
         ];
         $config->updateSettings($settings);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -351,7 +354,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
         self::assertSame(date('Y-m-d H:i', strtotime($settings['start-date'].' + 30 days')), $cfg['import-params']['start-date'], 'Invalid start-date after the first iteration');
         self::assertSame('import', $cfg['state']);
         // Run the same import again, to check the tag, group logic is not failing.
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);
@@ -376,7 +379,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
     public function testRunTransactionWithTransactionsPaging()
     {
         $this->setupTestConfig();
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         $config->updateState('import-init');
         $settings = [
             'client-id' => 'clientid',
@@ -391,7 +394,7 @@ class CRM_PaypalImporter_ImportProcessTest extends HeadlessTestCase
             'group-id' => 0,
         ];
         $config->updateSettings($settings);
-        $p = new CRM_PaypalImporter_ImportProcess(E::LONG_NAME, 'CRM_PaypalImporter_Request_AuthMock', 'CRM_PaypalImporter_Request_TransactionsPagingMock');
+        $p = new ImportProcess(E::LONG_NAME, 'Civi\PaypalImporter\Request\AuthMock', 'Civi\PaypalImporter\Request\TransactionsPagingMock');
         $result = $p->run(self::PARAMS);
         self::assertTrue(array_key_exists('is_error', $result));
         self::assertSame(0, $result['is_error']);

--- a/tests/phpunit/Civi/PaypalImporter/ImportProcessTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/ImportProcessTest.php
@@ -14,9 +14,9 @@ use CRM_PaypalImporter_ExtensionUtil as E;
 class ImportProcessTest extends HeadlessTestCase
 {
     // We don't use the params in the process script.
-    const PARAMS = [];
+    public const PARAMS = [];
 
-    const TEST_SETTINGS = [
+    public const TEST_SETTINGS = [
         'settings' => [
             'client-id' => '',
             'client-secret' => '',

--- a/tests/phpunit/Civi/PaypalImporter/LoaderTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/LoaderTest.php
@@ -6,7 +6,6 @@ use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 use Civi\Api4\Email;
 use CRM_Core_Exception;
-use TypeError;
 
 /**
  * @group headless
@@ -47,18 +46,6 @@ class LoaderTest extends HeadlessTestCase
             ->execute();
         $contact = $contacts->first();
         self::assertSame($contactData['contact_type'], $contact['contact_type'], 'Invalid contact_type has been returned');
-    }
-
-    /**
-     * @return void
-     * @throws \CRM_Core_Exception
-     */
-    public function testEmailMissingContactId()
-    {
-        $emailData = ['email' => 'testlooser@email.com'];
-        self::expectException(TypeError::class);
-        self::expectExceptionMessage('Argument 1 passed to CRM_PaypalImporter_Loader::email() must be of the type int, null given');
-        $emailId = Loader::email(null, $emailData);
     }
 
     /**

--- a/tests/phpunit/Civi/PaypalImporter/LoaderTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/LoaderTest.php
@@ -1,14 +1,17 @@
 <?php
 
+namespace Civi\PaypalImporter;
+
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
 use Civi\Api4\Email;
-use Civi\PaypalImporter\HeadlessTestCase;
+use CRM_Core_Exception;
+use TypeError;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
+class LoaderTest extends HeadlessTestCase
 {
     /**
      * @return void
@@ -17,7 +20,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
     public function testContactMissingData()
     {
         $contactData = [];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         self::assertIsInt($contactId);
     }
 
@@ -34,7 +37,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
             'first_name' => '',
             'last_name' => '',
         ];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         self::assertIsInt($contactId);
         // The contact is create well.
         $contacts = Contact::get(false)
@@ -55,7 +58,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         $emailData = ['email' => 'testlooser@email.com'];
         self::expectException(TypeError::class);
         self::expectExceptionMessage('Argument 1 passed to CRM_PaypalImporter_Loader::email() must be of the type int, null given');
-        $emailId = CRM_PaypalImporter_Loader::email(null, $emailData);
+        $emailId = Loader::email(null, $emailData);
     }
 
     /**
@@ -67,7 +70,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         $emailData = ['email' => 'testlooser@email.com'];
         self::expectException(CRM_Core_Exception::class);
         self::expectExceptionMessage('Invalid ID');
-        $emailId = CRM_PaypalImporter_Loader::email(-1, $emailData);
+        $emailId = Loader::email(-1, $emailData);
     }
 
     /**
@@ -82,11 +85,11 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
             'first_name' => '',
             'last_name' => '',
         ];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         $emailData = [];
         self::expectException(CRM_Core_Exception::class);
         self::expectExceptionMessage('Failed to create Email, reason: Mandatory values missing from Api4 Email::create: email');
-        $emailId = CRM_PaypalImporter_Loader::email($contactId, $emailData);
+        $emailId = Loader::email($contactId, $emailData);
     }
 
     /**
@@ -103,9 +106,9 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
             'first_name' => '',
             'last_name' => '',
         ];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         $emailData = ['email' => 'testlooser@email.com'];
-        $emailId = CRM_PaypalImporter_Loader::email($contactId, $emailData);
+        $emailId = Loader::email($contactId, $emailData);
         self::assertIsInt($emailId);
         $emails = Email::get(false)
             ->addSelect('email')
@@ -125,7 +128,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         $contribData = ['trxn_id' => 'a-1', 'total_amount' => 10];
         self::expectException(CRM_Core_Exception::class);
         self::expectExceptionMessage('Invalid ID');
-        $emailId = CRM_PaypalImporter_Loader::contribution(-1, $contribData);
+        $emailId = Loader::contribution(-1, $contribData);
     }
 
     /**
@@ -142,7 +145,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
             'first_name' => '',
             'last_name' => '',
         ];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         $contribData = ['trxn_id' => 'a-1', 'total_amount' => 10, 'financial_type_id' => 1];
         // The contribution shouldn't exists.
         $contributions = Contribution::get(false)
@@ -154,7 +157,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         if (is_array($contribution)) {
             self::fail('Contribution already exists.');
         }
-        $contributionId = CRM_PaypalImporter_Loader::contribution($contactId, $contribData);
+        $contributionId = Loader::contribution($contactId, $contribData);
         self::assertIsInt($contributionId);
         $contributions = Contribution::get(false)
             ->addSelect('trxn_id')
@@ -179,7 +182,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
             'first_name' => '',
             'last_name' => '',
         ];
-        $contactId = CRM_PaypalImporter_Loader::contact($contactData);
+        $contactId = Loader::contact($contactData);
         $contribData = ['trxn_id' => 'a-2', 'total_amount' => 10, 'financial_type_id' => 1];
         // The contribution shouldn't exists.
         $contributions = Contribution::get(false)
@@ -191,7 +194,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         if (is_array($contribution)) {
             self::fail('Contribution already exists.');
         }
-        $contributionId = CRM_PaypalImporter_Loader::contribution($contactId, $contribData);
+        $contributionId = Loader::contribution($contactId, $contribData);
         self::assertIsInt($contributionId);
         $contributions = Contribution::get(false)
             ->addSelect('trxn_id')
@@ -201,7 +204,7 @@ class CRM_PaypalImporter_LoaderTest extends HeadlessTestCase
         $contribution = $contributions->first();
         self::assertSame($contribData['trxn_id'], $contribution['trxn_id'], 'Invalid transaction has been returned');
         $contribData['source'] = 'test';
-        $newContributionId = CRM_PaypalImporter_Loader::contribution($contactId, $contribData);
+        $newContributionId = Loader::contribution($contactId, $contribData);
         self::assertSame($contributionId, $newContributionId, 'Insertion happened instead of update.');
     }
 }

--- a/tests/phpunit/Civi/PaypalImporter/Request/AuthCodeMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/AuthCodeMock.php
@@ -1,15 +1,17 @@
 <?php
 
-class CRM_PaypalImporter_Request_TransactionsCodeMock
+namespace Civi\PaypalImporter\Request;
+
+class AuthCodeMock
 {
     /**
      * Default Constructor
      *
      * @param string $host
-     * @param string $accessToken
-     * @param array $searchParams
+     * @param string $clientId
+     * @param string $clientSecret
      */
-    public function __construct(string $host, string $accessToken, array $searchParams = [])
+    public function __construct(string $host, string $clientId, string $clientSecret)
     {
     }
 

--- a/tests/phpunit/Civi/PaypalImporter/Request/AuthMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/AuthMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_AuthCodeMock
+namespace Civi\PaypalImporter\Request;
+
+class AuthMock
 {
     /**
      * Default Constructor
@@ -35,9 +37,9 @@ class CRM_PaypalImporter_Request_AuthCodeMock
     public function getResponse(): array
     {
         return [
-            'code' => 401,
+            'code' => 200,
             'headers' => [],
-            'data' => '',
+            'data' => '{"access_token":"fakeToken"}',
         ];
     }
 }

--- a/tests/phpunit/Civi/PaypalImporter/Request/AuthTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/AuthTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace Civi\PaypalImporter\Request;
+
 use Civi\PaypalImporter\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
+class AuthTest extends HeadlessTestCase
 {
     const TEST_DATA = [
         [
@@ -52,7 +54,7 @@ class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
     public function testGetHost()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
+            $req = new Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
@@ -64,8 +66,8 @@ class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
-            self::assertSame(CRM_PaypalImporter_Request_Auth::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
+            $req = new Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
+            self::assertSame(Auth::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
 
@@ -76,7 +78,7 @@ class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
+            $req = new Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
             self::assertSame(self::EXPECTED_OPTIONS, $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
@@ -88,14 +90,14 @@ class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
     public function testGetRequestHeaders()
     {
         $expectedHeaderBase = [
-            'Accept: '.CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
-            'Accept-Language: '.CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '.CRM_PaypalImporter_Request_Auth::CONTENT_TYPE_HEADER,
+            'Accept: '.Base::ACCEPT_HEADER,
+            'Accept-Language: '.Base::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.Auth::CONTENT_TYPE_HEADER,
             'Authorization: Basic ',
         ];
         foreach (self::TEST_DATA as $settings) {
             $expectedHeaderBase[3] = 'Authorization: Basic '.base64_encode($settings['clientId'].':'.$settings['clientSecret']);
-            $req = new CRM_PaypalImporter_Request_Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
+            $req = new Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
             self::assertSame($expectedHeaderBase, $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
@@ -107,7 +109,7 @@ class CRM_PaypalImporter_Request_AuthTest extends HeadlessTestCase
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
+            $req = new Auth($settings['host'], $settings['clientId'], $settings['clientSecret']);
             self::assertSame(self::EXPECTED_DATA, $req->getRequestData(), 'Invalid data configuration has been returned.');
         }
     }

--- a/tests/phpunit/Civi/PaypalImporter/Request/AuthTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/AuthTest.php
@@ -9,7 +9,7 @@ use Civi\PaypalImporter\HeadlessTestCase;
  */
 class AuthTest extends HeadlessTestCase
 {
-    const TEST_DATA = [
+    public const TEST_DATA = [
         [
             'host' => 'localhost',
             'clientId' => '',
@@ -32,7 +32,7 @@ class AuthTest extends HeadlessTestCase
         ],
     ];
 
-    const EXPECTED_OPTIONS = [
+    public const EXPECTED_OPTIONS = [
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 60,
@@ -43,7 +43,7 @@ class AuthTest extends HeadlessTestCase
         CURLOPT_FOLLOWLOCATION => true,
     ];
 
-    const EXPECTED_DATA = [
+    public const EXPECTED_DATA = [
         'grant_type' => 'client_credentials',
     ];
 

--- a/tests/phpunit/Civi/PaypalImporter/Request/AuthTokenMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/AuthTokenMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_AuthTokenMock
+namespace Civi\PaypalImporter\Request;
+
+class AuthTokenMock
 {
     /**
      * Default Constructor

--- a/tests/phpunit/Civi/PaypalImporter/Request/BaseTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/BaseTest.php
@@ -9,7 +9,7 @@ use Civi\PaypalImporter\HeadlessTestCase;
  */
 class BaseTest extends HeadlessTestCase
 {
-    const TEST_DATA = [
+    public const TEST_DATA = [
         [
             'host' => 'localhost',
             'endpoint' => '/api.php',

--- a/tests/phpunit/Civi/PaypalImporter/Request/BaseTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/BaseTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace Civi\PaypalImporter\Request;
+
 use Civi\PaypalImporter\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
+class BaseTest extends HeadlessTestCase
 {
     const TEST_DATA = [
         [
@@ -66,7 +68,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetHost()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
@@ -78,7 +80,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertSame($settings['endpoint'], $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
@@ -90,7 +92,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertSame($settings['options'], $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
@@ -102,7 +104,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetRequestHeaders()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertSame($settings['headers'], $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
@@ -114,7 +116,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertSame($settings['data'], $req->getRequestData(), 'Invalid data configuration has been returned.');
         }
     }
@@ -126,7 +128,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGet()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertEmpty($req->get());
         }
     }
@@ -138,7 +140,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testPost()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertEmpty($req->post());
         }
     }
@@ -150,7 +152,7 @@ class CRM_PaypalImporter_Request_BaseTest extends HeadlessTestCase
     public function testGetResponse()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
+            $req = new Base($settings['host'], $settings['endpoint'], $settings['options'], $settings['headers'], $settings['data']);
             self::assertEmpty($req->post());
             $resp = $req->getResponse();
             self::assertSame(404, $resp['code'], 'Invalid status code has been returned.');

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsCodeMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsCodeMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_TransactionsNoTransactionMock
+namespace Civi\PaypalImporter\Request;
+
+class TransactionsCodeMock
 {
     /**
      * Default Constructor
@@ -35,9 +37,9 @@ class CRM_PaypalImporter_Request_TransactionsNoTransactionMock
     public function getResponse(): array
     {
         return [
-            'code' => 200,
+            'code' => 401,
             'headers' => [],
-            'data' => '{"transaction_details":[], "total_pages":0, "last_refreshed_datetime": "'.date(DATE_ISO8601, strtotime('now -12 hours')).'"}',
+            'data' => '',
         ];
     }
 }

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsMissingEmailMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsMissingEmailMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_TransactionsMissingEmailMock
+namespace Civi\PaypalImporter\Request;
+
+class TransactionsMissingEmailMock
 {
     public const TRANSACTION_ID = '5TY05013RG002845M';
 

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_TransactionsMock
+namespace Civi\PaypalImporter\Request;
+
+class TransactionsMock
 {
     public const TRANSACTION_IDS = ['5TY05013RG002845M', '5TY05013RG002846M'];
 

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsNoTransactionMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsNoTransactionMock.php
@@ -1,15 +1,17 @@
 <?php
 
-class CRM_PaypalImporter_Request_AuthMock
+namespace Civi\PaypalImporter\Request;
+
+class TransactionsNoTransactionMock
 {
     /**
      * Default Constructor
      *
      * @param string $host
-     * @param string $clientId
-     * @param string $clientSecret
+     * @param string $accessToken
+     * @param array $searchParams
      */
-    public function __construct(string $host, string $clientId, string $clientSecret)
+    public function __construct(string $host, string $accessToken, array $searchParams = [])
     {
     }
 
@@ -37,7 +39,7 @@ class CRM_PaypalImporter_Request_AuthMock
         return [
             'code' => 200,
             'headers' => [],
-            'data' => '{"access_token":"fakeToken"}',
+            'data' => '{"transaction_details":[], "total_pages":0, "last_refreshed_datetime": "'.date(DATE_ISO8601, strtotime('now -12 hours')).'"}',
         ];
     }
 }

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsPagingMock.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsPagingMock.php
@@ -1,6 +1,8 @@
 <?php
 
-class CRM_PaypalImporter_Request_TransactionsPagingMock
+namespace Civi\PaypalImporter\Request;
+
+class TransactionsPagingMock
 {
     public const TRANSACTION_IDS = ['5TY05013RG002848M', '5TY05013RG002849M'];
 

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsTest.php
@@ -9,7 +9,7 @@ use Civi\PaypalImporter\HeadlessTestCase;
  */
 class TransactionsTest extends HeadlessTestCase
 {
-    const TEST_DATA = [
+    public const TEST_DATA = [
         [
             'host' => 'localhost',
             'token' => '',
@@ -38,7 +38,7 @@ class TransactionsTest extends HeadlessTestCase
         ],
     ];
 
-    const EXPECTED_OPTIONS = [
+    public const EXPECTED_OPTIONS = [
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 60,

--- a/tests/phpunit/Civi/PaypalImporter/Request/TransactionsTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/Request/TransactionsTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace Civi\PaypalImporter\Request;
+
 use Civi\PaypalImporter\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
+class TransactionsTest extends HeadlessTestCase
 {
     const TEST_DATA = [
         [
@@ -54,7 +56,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
     public function testGetHost()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Transactions($settings['host'], $settings['token'], $settings['data']);
+            $req = new Transactions($settings['host'], $settings['token'], $settings['data']);
             self::assertSame($settings['host'], $req->getHost(), 'Invalid host configuration has been returned.');
         }
     }
@@ -66,8 +68,8 @@ class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
     public function testGetEndpoint()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Transactions($settings['host'], $settings['token'], $settings['data']);
-            self::assertSame(CRM_PaypalImporter_Request_Transactions::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
+            $req = new Transactions($settings['host'], $settings['token'], $settings['data']);
+            self::assertSame(Transactions::ENDPOINT, $req->getEndpoint(), 'Invalid endpoint configuration has been returned.');
         }
     }
 
@@ -78,7 +80,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
     public function testGetOptions()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Transactions($settings['host'], $settings['token'], $settings['data']);
+            $req = new Transactions($settings['host'], $settings['token'], $settings['data']);
             self::assertSame(self::EXPECTED_OPTIONS, $req->getOptions(), 'Invalid options configuration has been returned.');
         }
     }
@@ -90,14 +92,14 @@ class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
     public function testGetRequestHeaders()
     {
         $expectedHeaderBase = [
-            'Accept: '.CRM_PaypalImporter_Request_Base::ACCEPT_HEADER,
-            'Accept-Language: '.CRM_PaypalImporter_Request_Base::ACCEPT_LANGUAGE_HEADER,
-            'Content-Type: '.CRM_PaypalImporter_Request_Transactions::CONTENT_TYPE_HEADER,
+            'Accept: '.Base::ACCEPT_HEADER,
+            'Accept-Language: '.Base::ACCEPT_LANGUAGE_HEADER,
+            'Content-Type: '.Transactions::CONTENT_TYPE_HEADER,
             'Authorization: Basic ',
         ];
         foreach (self::TEST_DATA as $settings) {
             $expectedHeaderBase[3] = 'Authorization: Bearer '.$settings['token'];
-            $req = new CRM_PaypalImporter_Request_Transactions($settings['host'], $settings['token'], $settings['data']);
+            $req = new Transactions($settings['host'], $settings['token'], $settings['data']);
             self::assertSame($expectedHeaderBase, $req->getRequestHeaders(), 'Invalid headers configuration has been returned.');
         }
     }
@@ -109,7 +111,7 @@ class CRM_PaypalImporter_Request_TransactionsTest extends HeadlessTestCase
     public function testGetRequestData()
     {
         foreach (self::TEST_DATA as $settings) {
-            $req = new CRM_PaypalImporter_Request_Transactions($settings['host'], $settings['token'], $settings['data']);
+            $req = new Transactions($settings['host'], $settings['token'], $settings['data']);
             self::assertSame($settings['data'], $req->getRequestData(), 'Invalid data configuration has been returned.');
         }
     }

--- a/tests/phpunit/Civi/PaypalImporter/TransformerTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/TransformerTest.php
@@ -7,7 +7,7 @@ namespace Civi\PaypalImporter;
  */
 class TransformerTest extends HeadlessTestCase
 {
-    const PAYPAL_SAMPLE_DATA = [
+    public const PAYPAL_SAMPLE_DATA = [
         'transaction_info' => [
             'paypal_account_id' => '6STWC2LSUYYYE',
             'transaction_id' => '5TY05013RG002845M',

--- a/tests/phpunit/Civi/PaypalImporter/TransformerTest.php
+++ b/tests/phpunit/Civi/PaypalImporter/TransformerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Civi\PaypalImporter\HeadlessTestCase;
+namespace Civi\PaypalImporter;
 
 /**
  * @group headless
  */
-class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
+class TransformerTest extends HeadlessTestCase
 {
     const PAYPAL_SAMPLE_DATA = [
         'transaction_info' => [
@@ -153,7 +153,7 @@ class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
             'first_name' => self::PAYPAL_SAMPLE_DATA['payer_info']['payer_name']['given_name'],
             'last_name' => self::PAYPAL_SAMPLE_DATA['payer_info']['payer_name']['surname'],
         ];
-        $transformedContact = CRM_PaypalImporter_Transformer::paypalTransactionToContact(self::PAYPAL_SAMPLE_DATA);
+        $transformedContact = Transformer::paypalTransactionToContact(self::PAYPAL_SAMPLE_DATA);
         self::assertSame($expectedContactData, $transformedContact, 'Invalid transformed data.');
     }
 
@@ -168,7 +168,7 @@ class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
             'location_type_id' => 1,
             'email' => self::PAYPAL_SAMPLE_DATA['payer_info']['email_address'],
         ];
-        $transformedEmail = CRM_PaypalImporter_Transformer::paypalTransactionToEmail(self::PAYPAL_SAMPLE_DATA);
+        $transformedEmail = Transformer::paypalTransactionToEmail(self::PAYPAL_SAMPLE_DATA);
         self::assertSame($expectedEmailData, $transformedEmail, 'Invalid transformed data.');
     }
 
@@ -187,7 +187,7 @@ class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
             'source' => self::PAYPAL_SAMPLE_DATA['cart_info']['item_details'][0]['item_name'] ?: '',
             'contribution_status_id' => 1,
         ];
-        $transformedContribution = CRM_PaypalImporter_Transformer::paypalTransactionToContribution(self::PAYPAL_SAMPLE_DATA);
+        $transformedContribution = Transformer::paypalTransactionToContribution(self::PAYPAL_SAMPLE_DATA);
         self::assertSame($expectedContributionData, $transformedContribution, 'Invalid transformed data.');
     }
 
@@ -209,7 +209,7 @@ class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
         ];
         $refundTransaction = self::PAYPAL_SAMPLE_DATA;
         $refundTransaction['transaction_info']['transaction_status'] = 'V';
-        $transformedContribution = CRM_PaypalImporter_Transformer::paypalTransactionToContribution($refundTransaction);
+        $transformedContribution = Transformer::paypalTransactionToContribution($refundTransaction);
         self::assertSame($expectedContributionData, $transformedContribution, 'Invalid transformed data.');
     }
 
@@ -230,7 +230,7 @@ class CRM_PaypalImporter_TransformerTest extends HeadlessTestCase
         ];
         $refundTransaction = self::PAYPAL_SAMPLE_DATA;
         $refundTransaction['transaction_info']['transaction_status'] = 'XX';
-        $transformedContribution = CRM_PaypalImporter_Transformer::paypalTransactionToContribution($refundTransaction);
+        $transformedContribution = Transformer::paypalTransactionToContribution($refundTransaction);
         self::assertSame($expectedContributionData, $transformedContribution, 'Invalid transformed data.');
     }
 }

--- a/tests/phpunit/api/v3/PaypalImporter/ImportTest.php
+++ b/tests/phpunit/api/v3/PaypalImporter/ImportTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\PaypalImporter\Config;
 use Civi\PaypalImporter\HeadlessTestCase;
 use CRM_PaypalImporter_ExtensionUtil as E;
 
@@ -35,7 +36,7 @@ class api_v3_PaypalImporter_ImportTest extends HeadlessTestCase
      */
     public function testApiCall()
     {
-        $config = new CRM_PaypalImporter_Config(E::LONG_NAME);
+        $config = new Config(E::LONG_NAME);
         self::assertTrue($config->update(self::TEST_SETTINGS), 'Config update has to be successful.');
         $result = civicrm_api3('PaypalImporter', 'import');
         $this->assertEquals(self::TEST_SETTINGS['state'], $result['values']['state']);

--- a/tests/phpunit/api/v3/PaypalImporter/ImportTest.php
+++ b/tests/phpunit/api/v3/PaypalImporter/ImportTest.php
@@ -9,7 +9,7 @@ use CRM_PaypalImporter_ExtensionUtil as E;
  */
 class api_v3_PaypalImporter_ImportTest extends HeadlessTestCase
 {
-    const TEST_SETTINGS = [
+    public const TEST_SETTINGS = [
         'settings' => [
             'client-id' => '',
             'client-secret' => '',


### PR DESCRIPTION
- move classes to `\Civi\ExtensionName` namespace
- no manual changes
